### PR TITLE
Fixed links in Readme - #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # advpl-vscode README
 
-Bem vindo a extensão para desenvolvimento de Advpl no visual code. [VsCode MarketPlace](https://github.com/killerall/advpl-vscode)
+Bem vindo a extensão para desenvolvimento de Advpl no visual code. [VsCode MarketPlace](https://marketplace.visualstudio.com/items?itemName=KillerAll.advpl-vscode)
 
 Essa extensão adiciona suporte a edição, compilação e debugging de ADVPL no Visual Code.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bem vindo a extensão para desenvolvimento de Advpl no visual code. [VsCode Mark
 
 Essa extensão adiciona suporte a edição, compilação e debugging de ADVPL no Visual Code.
 
-Caso você encontre algum problema, por favor abra uma issue no [GitHub](http://link). 
+Caso você encontre algum problema, por favor abra uma issue no [GitHub](https://github.com/killerall/advpl-vscode/issues). 
 
 > Atenção! Essa extensão não é desenvolvida ou suportada pela TOTVS. Utilize por sua conta e risco.
 


### PR DESCRIPTION
Changed links in readme to point correctly to Github and VSCode MarketPlace