### PR TITLE
Atualização em menu de contexto

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "contributes": {
         "menus": {
             "explorer/context": [
-                {
-                    "when": "fold",
+                {                    
                     "command": "advpl.menucompile"
                 },
                 {


### PR DESCRIPTION
Liberado menu de contexto para compilar somente um fonte, antes havia apenas a opção de compilar a pasta inteira.