### PR TITLE
Support webservices compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
                 },
                 "advpl.compileFolderRegex": {
                     "type": "string",
-                    "default": ".*\\.(prw|prx|prg|apw|aph|tres|png|bmp|res)",
+                    "default": ".*\\.(prw|apw|prx|prg|apw|aph|tres|png|bmp|res)",
                     "description": "Regex dos tipos de arquivos que serão compilados quando selecionar compilação de pasta"
                 },
                 "advpl.pathPatchBuild": {
@@ -237,6 +237,7 @@
                 "id": "advpl",
                 "extensions": [
                     ".prw",
+                    ".apw",
                     ".prx",
                     ".prg",
                     ".aph",
@@ -244,6 +245,7 @@
                 ],
                 "aliases": [
                     "Advpl(PRW)",
+                    "Advpl(APW)",
                     "Advpl(PRX)",
                     "Advpl(PRG)",
                     "Advpl(APH)",


### PR DESCRIPTION
The extension `.apw` is used to represent AdvPL webservices. For now, when you open an `.apw` file, you don't have syntax highlight because it is not identified as an AdvPL source. This pull-request fixes it by adding `.apw` to the supported extensions.