### PR TITLE
Extensão .APL

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
                 },
                 "advpl.compileFolderRegex": {
                     "type": "string",
-                    "default": ".*\\.(prw|prx|prg|apw|aph|tres|png|bmp|res)",
+                    "default": ".*\\.(prw|prx|prg|apw|aph|tres|png|bmp|res|apl)",
                     "description": "Regex dos tipos de arquivos que serão compilados quando selecionar compilação de pasta"
                 },
                 "advpl.pathPatchBuild": {


### PR DESCRIPTION
Inclusão da extensão .APL para a compilação de pasta.