### PR TITLE
Correção de mensagem em caso de erro de compilação

### DIFF
--- a/i18n/enu/out/src/advplCompile.i18n.json
+++ b/i18n/enu/out/src/advplCompile.i18n.json
@@ -14,6 +14,7 @@
 	"src.advplCompile.errorText": "Error in ",
 	"src.advplCompile.warningText": "Warning: ",
 	"src.advplCompile.compilationFinishedErrorsText": "Compilation finished with errors, check the Problems tab!",
+	"src.advplCompile.compilationAbortedText": "Compilation aborted, check the log or the Problems tab!",
 	"src.advplCompile.compilationFinishedOkText": "Compilation finished successfully.",
 	"src.advplCompile.informSourcesExclusionText": "Inform the sources to be excluded:",
 	"src.advplCompile.istartSourcesExclusionText": "Starting the exclusion of the sources...",

--- a/i18n/esn/out/src/advplCompile.i18n.json
+++ b/i18n/esn/out/src/advplCompile.i18n.json
@@ -14,6 +14,7 @@
 	"src.advplCompile.errorText": "Error en ",
 	"src.advplCompile.warningText": "Aviso: ",
 	"src.advplCompile.compilationFinishedErrorsText": "Compilación finalizada con errores, verifique la solapa problemas!",
+	"src.advplCompile.compilationAbortedText": "Compilación abortada, compruebe el registro o la pestaña Problemas!",
 	"src.advplCompile.compilationFinishedOkText": "Compilación finalizada exitosamente.",
 	"src.advplCompile.informSourcesExclusionText": "Informe los fuentes a ser excluidos:",
 	"src.advplCompile.istartSourcesExclusionText": "Iniciando la exclusión de los fuentes...",

--- a/i18n/ptb/out/src/advplCompile.i18n.json
+++ b/i18n/ptb/out/src/advplCompile.i18n.json
@@ -14,6 +14,7 @@
 	"src.advplCompile.errorText": "Erro no ",
 	"src.advplCompile.warningText": "Aviso: ",
 	"src.advplCompile.compilationFinishedErrorsText": "Compilação finalizada com erros, verifique a aba problemas!",
+	"src.advplCompile.compilationAbortedText": "Compilação abortada, verifique o log ou a aba Problemas!",
 	"src.advplCompile.compilationFinishedOkText": "Compilação finalizada com sucesso.",
 	"src.advplCompile.informSourcesExclusionText": "Informe os fontes a serem excluídos:",
 	"src.advplCompile.istartSourcesExclusionText": "Iniciando a exclusão dos fontes...",

--- a/i18n/rus/out/src/advplCompile.i18n.json
+++ b/i18n/rus/out/src/advplCompile.i18n.json
@@ -14,6 +14,7 @@
 	"src.advplCompile.errorText": "Ошибка в ",
 	"src.advplCompile.warningText": "Предупреждающий: ",
 	"src.advplCompile.compilationFinishedErrorsText": "Компиляция закончена с ошибками, проверьте вкладку проблемы!",
+	"src.advplCompile.compilationAbortedText": "Компиляция отменена, проверьте журнал или вкладку «Проблемы»!",
 	"src.advplCompile.compilationFinishedOkText": "Компиляция успешно завершена.",
 	"src.advplCompile.informSourcesExclusionText": "Сообщите источники, которые будут исключены:",
 	"src.advplCompile.istartSourcesExclusionText": "Начало исключения источников...",

--- a/src/advplCompile.ts
+++ b/src/advplCompile.ts
@@ -232,6 +232,8 @@ export class advplCompile {
 
     private run_callBack(lOk) {
         let lErrorFound;
+        let lAbort;
+
         try {
             if (this._lastAppreMsg != null) {
                 var oEr = JSON.parse(this._lastAppreMsg);
@@ -253,6 +255,10 @@ export class advplCompile {
                         if (source == "NOSOURCE") {
                             //vscode.window.showInformationMessage(message);
                             this.outChannel.log(message);
+                            if(msgerr.Type == 0) {
+                                lErrorFound = true;
+                                lAbort = true;
+                            }
                         }
                         else {
                             if (msgerr.Type == 0) {
@@ -282,7 +288,7 @@ export class advplCompile {
 
             if (lOk) {
                 this.outChannel.log(lErrorFound ?
-                    localize("src.advplCompile.compilationFinishedErrorsText", "Compilation finished with errors, check the Problems tab!") :
+                    ( lAbort ? localize("src.advplCompile.compilationAbortedText", "Compilation aborted, check the log or the Problems tab!") : localize("src.advplCompile.compilationFinishedErrorsText", "Compilation finished with errors, check the Problems tab!") ) :
                     localize("src.advplCompile.compilationFinishedOkText", "Compilation finished successfully."));
                 this.afterCompile();
             }


### PR DESCRIPTION
Alteração para que caso exista algum erro na chave de compilação ou password, o vscode informe que a compilação foi abortada e não uma mensagem de compilação finalizada com sucesso.